### PR TITLE
[Refactor] Use `host` concept, instead of mixing it with `URL`

### DIFF
--- a/pyqube/__init__.py
+++ b/pyqube/__init__.py
@@ -2,7 +2,7 @@ from pyqube.events.clients import MQTTClient
 from pyqube.rest.clients import RestClient
 
 
-class QubeClient(MQTTClient, RestClient):
+class QubeClient(RestClient, MQTTClient):
     """
     A unified client that combines both MQTT and REST capabilities.
     It supports interacting with MQTT brokers for real-time messaging and with a REST API for general requests.
@@ -12,9 +12,9 @@ class QubeClient(MQTTClient, RestClient):
         self,
         api_key: str,
         location_id: int,
-        broker_url: str = None,
+        api_host: str = None,
+        broker_host: str = None,
         broker_port: int = None,
-        base_url: str = None,
         queue_management_manager: object = None
     ):
         """
@@ -23,10 +23,10 @@ class QubeClient(MQTTClient, RestClient):
         Args:
             api_key (str): API key for client authentication.
             location_id (int): Location ID to use in requests.
-            broker_url (str, optional): URL of the MQTT broker. Defaults to MQTTClient.DEFAULT_BROKER_URL.
+            api_host (str, optional): Host for REST API requests. Defaults to RestClient.DEFAULT_API_HOST.
+            broker_host (str, optional): Host of the MQTT broker. Defaults to MQTTClient.DEFAULT_BROKER_HOST.
             broker_port (int, optional): Port of the MQTT broker. Defaults to MQTTClient.DEFAULT_BROKER_PORT.
-            base_url (str, optional): Base URL for REST API requests. Defaults to RestClient.API_BASE_URL.
             queue_management_manager (object, optional): Manager used for queue management via REST API.
         """
-        MQTTClient.__init__(self, api_key, location_id, broker_url, broker_port)
-        RestClient.__init__(self, api_key, location_id, queue_management_manager, base_url)
+        RestClient.__init__(self, api_key, location_id, queue_management_manager, api_host)
+        MQTTClient.__init__(self, api_key, location_id, broker_host, broker_port)

--- a/pyqube/events/clients.py
+++ b/pyqube/events/clients.py
@@ -16,24 +16,24 @@ class MQTTClient(TicketHandler, QueuingSystemResetHandler, QueueHandler):
     and handling message events with user-defined handlers.
     """
 
-    DEFAULT_BROKER_URL = "mqtt.qube.q-better.com"
+    DEFAULT_BROKER_HOST = "mqtt.qube.q-better.com"
     DEFAULT_BROKER_PORT = 443
 
-    def __init__(self, api_key: str, location_id: id, broker_url: str = None, broker_port: int = None):
+    def __init__(self, api_key: str, location_id: id, broker_host: str = None, broker_port: int = None):
         """
         Initializes and connects the MQTT client.
 
         Args:
             api_key (str): API key for client authentication.
             location_id (int): Location ID to use in requests.
-            broker_url (str, optional): URL of the MQTT broker. Defaults to DEFAULT_BROKER_URL.
+            broker_host (str, optional): Host of the MQTT broker. Defaults to DEFAULT_BROKER_HOST.
             broker_port (int, optional): Port of the MQTT broker. Defaults to DEFAULT_BROKER_PORT.
         Raises:
             ConnectionError: If unable to connect to the broker.
         """
 
         super().__init__()
-        self.broker_url = broker_url or self.DEFAULT_BROKER_URL
+        self.broker_host = broker_host or self.DEFAULT_BROKER_HOST
         self.broker_port = broker_port or self.DEFAULT_BROKER_PORT
         self.location_id = location_id
 
@@ -61,10 +61,10 @@ class MQTTClient(TicketHandler, QueuingSystemResetHandler, QueueHandler):
     def _connect_to_broker(self) -> None:
         """Connects to the MQTT broker and starts the network loop."""
         try:
-            self.client.connect(host=self.broker_url, port=self.broker_port, keepalive=60)
+            self.client.connect(host=self.broker_host, port=self.broker_port, keepalive=60)
             self.client.loop_start()
         except Exception as e:
-            raise ConnectionError(f"Failed to connect to MQTT broker at {self.broker_url}:{self.broker_port}: {e}")
+            raise ConnectionError(f"Failed to connect to MQTT broker at {self.broker_host}:{self.broker_port}: {e}")
 
     def disconnect(self) -> None:
         """Stops the MQTT loop and disconnects from the broker."""

--- a/pyqube/events/tests/test_mqtt_client.py
+++ b/pyqube/events/tests/test_mqtt_client.py
@@ -28,21 +28,21 @@ class TestMQTTClient(unittest.TestCase):
         self.mock_client.tls_insecure_set.assert_called_once_with(False)
 
     def test_connect_to_broker(self):
-        """Test that the client connects to the broker with correct URL and port"""
+        """Test that the client connects to the broker with correct host and port"""
         self.mock_client.connect.assert_called_once_with(
-            host=MQTTClient.DEFAULT_BROKER_URL, port=MQTTClient.DEFAULT_BROKER_PORT, keepalive=60
+            host=MQTTClient.DEFAULT_BROKER_HOST, port=MQTTClient.DEFAULT_BROKER_PORT, keepalive=60
         )
         self.mock_client.loop_start.assert_called_once()
 
-    def test_initialization_with_custom_broker_url_and_port(self):
-        """Test that the client initializes with custom broker URL and port"""
-        custom_broker_url = "custom.broker.url"
+    def test_initialization_with_custom_broker_host_and_port(self):
+        """Test that the client initializes with custom broker host and port"""
+        custom_broker_host = "custom.broker.host"
         custom_broker_port = 1883
         client = MQTTClient(
-            api_key=self.api_key, broker_url=custom_broker_url, broker_port=custom_broker_port, location_id=1
+            api_key=self.api_key, broker_host=custom_broker_host, broker_port=custom_broker_port, location_id=1
         )
 
-        self.assertEqual(client.broker_url, custom_broker_url)
+        self.assertEqual(client.broker_host, custom_broker_host)
         self.assertEqual(client.broker_port, custom_broker_port)
 
     def test_disconnect(self):

--- a/pyqube/rest/clients.py
+++ b/pyqube/rest/clients.py
@@ -12,18 +12,18 @@ class RestClient:
     (default or not) and making some requests to API Server.
     """
 
-    API_BASE_URL = "https://api.qube.q-better.com/en/api/v1"
+    DEFAULT_API_HOST = "api.qube.q-better.com"
 
-    def __init__(self, api_key: str, location_id: int, queue_management_manager: object = None, base_url: str = None):
+    def __init__(self, api_key: str, location_id: int, queue_management_manager: object = None, api_host: str = None):
         """
         Initializes the Rest Client.
         Args:
             api_key (str): API key for client authentication.
             location_id (int): Location's id that will be used in requests.
             queue_management_manager (object, optional): Manager used on API Server interactions. Defaults to None.
-            base_url (str, optional): Base url used on API interactions . Defaults to API_BASE_URL.
+            api_host (str, optional): Base host used on API interactions . Defaults to DEFAULT_API_HOST.
         """
-        self.base_url = base_url or self.API_BASE_URL
+        self.base_url = f"https://{api_host or self.DEFAULT_API_HOST}/en/api/v1"
         self.api_key = api_key
         self.headers = {
             "AUTHORIZATION": "Api-Key " + api_key,

--- a/pyqube/rest/tests/test_call_next_ticket_ending_current.py
+++ b/pyqube/rest/tests/test_call_next_ticket_ending_current.py
@@ -20,11 +20,11 @@ from pyqube.types import Answering
 class TestCallNextTicketEndingCurrent(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "http://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         self.answering_data = {
             'id': 1,

--- a/pyqube/rest/tests/test_end_answering.py
+++ b/pyqube/rest/tests/test_end_answering.py
@@ -22,11 +22,11 @@ from pyqube.types import Answering
 class TestEndAnswering(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         self.answering_data = {
             'id': 1,

--- a/pyqube/rest/tests/test_generate_ticket.py
+++ b/pyqube/rest/tests/test_generate_ticket.py
@@ -18,11 +18,11 @@ from pyqube.types import Ticket
 class TestGenerateTicket(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         self.ticket_data = {
             "id": 1,

--- a/pyqube/rest/tests/test_get_current_answering.py
+++ b/pyqube/rest/tests/test_get_current_answering.py
@@ -16,11 +16,11 @@ from pyqube.types import Answering
 class TestGetCurrentAnswering(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         self.answering_data = {
             'id': 1,

--- a/pyqube/rest/tests/test_list_queues.py
+++ b/pyqube/rest/tests/test_list_queues.py
@@ -16,11 +16,11 @@ from pyqube.types import Queue
 class TestListQueues(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         base_queue_fields = {
             'is_active': True,
@@ -113,7 +113,7 @@ class TestListQueues(unittest.TestCase):
         """Test list queues paginated and checks if a list of Queues is returned"""
         list_queues_path = f"/locations/{self.location_id}/queues/"
 
-        self.page_1_list_of_queues_response["next"] = f"https://api-url-qube.com{list_queues_path}?page=2"
+        self.page_1_list_of_queues_response["next"] = f"https://api.qube.com{list_queues_path}?page=2"
         mock_get_request.return_value.json.side_effect = [
             self.page_1_list_of_queues_response, self.page_2_list_of_queues_response
         ]

--- a/pyqube/rest/tests/test_list_queues_of_queues_list.py
+++ b/pyqube/rest/tests/test_list_queues_of_queues_list.py
@@ -18,13 +18,13 @@ from pyqube.types import Queue
 class TestListQueuesOfQueuesList(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
         self.location_id_encoded = base64.b64encode(f"LocationNode:{self.location_id}".encode('utf-8')).decode('utf-8')
         self.queues_list_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         base_queue_fields = {
             'is_active': True,

--- a/pyqube/rest/tests/test_rest_client.py
+++ b/pyqube/rest/tests/test_rest_client.py
@@ -10,15 +10,16 @@ from pyqube.rest.queue_management_manager import QueueManagementManager
 class TestRestClient(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
+        self._base_url = f"https://{self.api_host}/en/api/v1"
         self.api_key = 'api_key'
         self.location_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
     def test_initialization_with_correct_credentials(self):
         """Test that the client initializes with correct credentials"""
-        self.assertEqual(self.qube_rest_client.base_url, self.base_url)
+        self.assertEqual(self.qube_rest_client.base_url, self._base_url)
         self.assertEqual(self.qube_rest_client.api_key, self.api_key)
         self.assertEqual(self.qube_rest_client.location_id, self.location_id)
 
@@ -40,7 +41,7 @@ class TestRestClient(unittest.TestCase):
             self.api_key,
             self.location_id,
             queue_management_manager=custom_queue_management_manager,
-            base_url=self.base_url
+            api_host=self.api_host
         )
         queue_management_manager_returned = qube_rest_client.get_queue_management_manager()
 
@@ -55,7 +56,7 @@ class TestRestClient(unittest.TestCase):
         }
         self.qube_rest_client.get_request(path, params)
         mock_requests_get.assert_called_once_with(
-            self.base_url + path, headers=self.qube_rest_client.headers, params=params, timeout=10
+            self._base_url + path, headers=self.qube_rest_client.headers, params=params, timeout=10
         )
 
     @patch.object(requests, "post")
@@ -70,7 +71,7 @@ class TestRestClient(unittest.TestCase):
         }
         self.qube_rest_client.post_request(path, params, data)
         mock_requests_get.assert_called_once_with(
-            self.base_url + path, headers=self.qube_rest_client.headers, params=params, data=data, timeout=10
+            self._base_url + path, headers=self.qube_rest_client.headers, params=params, data=data, timeout=10
         )
 
     @patch.object(requests, "put")
@@ -85,5 +86,5 @@ class TestRestClient(unittest.TestCase):
         }
         self.qube_rest_client.put_request(path, params, data)
         mock_requests_get.assert_called_once_with(
-            self.base_url + path, headers=self.qube_rest_client.headers, params=params, data=data, timeout=10
+            self._base_url + path, headers=self.qube_rest_client.headers, params=params, data=data, timeout=10
         )

--- a/pyqube/rest/tests/test_set_current_counter.py
+++ b/pyqube/rest/tests/test_set_current_counter.py
@@ -17,13 +17,13 @@ from pyqube.types import LocationAccessWithCurrentCounter
 class TestSetCurrentCounter(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
         self.location_access_id = 1
         self.counter_id = 1
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         self.location_access_with_counter_data = {
             'id': self.location_access_id,

--- a/pyqube/rest/tests/test_set_queue_status.py
+++ b/pyqube/rest/tests/test_set_queue_status.py
@@ -17,7 +17,7 @@ from pyqube.types import Queue
 class TestSetQueueStatus(unittest.TestCase):
 
     def setUp(self):
-        self.base_url = "https://api-url-qube.com"
+        self.api_host = "api.qube.com"
         self.api_key = 'api_key'
         self.location_id = 1
         self.location_access_id = 1
@@ -25,7 +25,7 @@ class TestSetQueueStatus(unittest.TestCase):
         self.queue_id = 1
         self.is_active = True
 
-        self.qube_rest_client = RestClient(self.api_key, self.location_id, base_url=self.base_url)
+        self.qube_rest_client = RestClient(self.api_key, self.location_id, api_host=self.api_host)
 
         self.queue_data = {
             'id': self.queue_id,


### PR DESCRIPTION
- Changed QubeClient to initialize with `api_host` and `broker_host` instead of `base_url` and `broker_url`
- Fixed MQTTClient to use `broker_host` instead of `broker_url`
- Adjusted related tests to reflect the new parameter names