### PR TITLE
[Refactor] Enable subscription to ticket calls from/to any queue/counter

### DIFF
--- a/pyqube/events/handlers.py
+++ b/pyqube/events/handlers.py
@@ -218,7 +218,7 @@ class TicketHandler(MQTTEventHandlerBase, ABC):
             The decorator for the handler function.
 
         Raises:
-            InvalidTicketHandlerArgumentsError: If both or neither `queue_id` and `counter_id` are provided.
+            InvalidTicketHandlerArgumentsError: If both `queue_id` and `counter_id` are provided.
         """
         # Check that exactly one of the arguments is provided
         if (queue_id is not None) and (counter_id is not None):

--- a/pyqube/events/handlers.py
+++ b/pyqube/events/handlers.py
@@ -226,7 +226,7 @@ class TicketHandler(MQTTEventHandlerBase, ABC):
                 "You can only provide one of 'queue_id' or 'counter_id', not both."
             )
         if (queue_id is None) and (counter_id is None):
-            raise InvalidTicketHandlerArgumentsError("You must provide exactly one of 'queue_id' or 'counter_id'.")
+            queue_id = '+'
 
         topic = f"locations/{self.location_id}"
         if queue_id is not None:

--- a/pyqube/events/tests/test_ticket_handler.py
+++ b/pyqube/events/tests/test_ticket_handler.py
@@ -22,6 +22,13 @@ class TestTicketHandler:
         handler.location_id = 1
         return handler
 
+    @pytest.fixture
+    def mock_add_mqtt_handler(self):
+        """Fixture to mock add_mqtt_handler method of ConcreteTicketHandler."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(ConcreteTicketHandler, 'add_mqtt_handler', Mock())
+            yield
+
     def test_on_ticket_generated(self, ticket_handler):
         """Test that on_ticket_generated registers the correct handler."""
         handler = ticket_handler.on_ticket_generated()
@@ -32,9 +39,8 @@ class TestTicketHandler:
         handler = ticket_handler.on_ticket_called(counter_id=124)
         assert handler is not None
 
-    def test_on_ticket_called_with_counter_id_builds_correct_topic(self, ticket_handler):
+    def test_on_ticket_called_with_counter_id_builds_correct_topic(self, ticket_handler, mock_add_mqtt_handler):
         """Test that on_ticket_called builds the correct topic for queue_id."""
-        ticket_handler.add_mqtt_handler = Mock()
         ticket_handler.on_ticket_called(counter_id=124)
         ticket_handler.add_mqtt_handler.assert_called_once_with(
             "locations/1/counters/124/tickets/called", AnsweringTicket
@@ -45,9 +51,8 @@ class TestTicketHandler:
         handler = ticket_handler.on_ticket_called(queue_id=90)
         assert handler is not None
 
-    def test_on_ticket_called_with_queue_id_builds_correct_topic(self, ticket_handler):
+    def test_on_ticket_called_with_queue_id_builds_correct_topic(self, ticket_handler, mock_add_mqtt_handler):
         """Test that on_ticket_called builds the correct topic for queue_id."""
-        ticket_handler.add_mqtt_handler = Mock()
         ticket_handler.on_ticket_called(queue_id=90)
         ticket_handler.add_mqtt_handler.assert_called_once_with("locations/1/queues/90/tickets/called", AnsweringTicket)
 
@@ -56,9 +61,8 @@ class TestTicketHandler:
         handler = ticket_handler.on_ticket_called()
         assert handler is not None
 
-    def test_on_ticket_called_with_no_arguments_builds_correct_topic(self, ticket_handler):
+    def test_on_ticket_called_with_no_arguments_builds_correct_topic(self, ticket_handler, mock_add_mqtt_handler):
         """Test that on_ticket_called builds the correct topic when no arguments are provided."""
-        ticket_handler.add_mqtt_handler = Mock()
         ticket_handler.on_ticket_called()
         ticket_handler.add_mqtt_handler.assert_called_once_with("locations/1/queues/+/tickets/called", AnsweringTicket)
 
@@ -72,8 +76,7 @@ class TestTicketHandler:
         handler = ticket_handler.on_ticket_changed_state()
         assert handler is not None
 
-    def test_on_ticket_changed_state_builds_correct_topic(self, ticket_handler):
+    def test_on_ticket_changed_state_builds_correct_topic(self, ticket_handler, mock_add_mqtt_handler):
         """Test that on_ticket_changed_state builds the correct topic."""
-        ticket_handler.add_mqtt_handler = Mock()
         ticket_handler.on_ticket_changed_state()
         ticket_handler.add_mqtt_handler.assert_called_once_with("locations/1/tickets/+/changed-state", PublicTicket)

--- a/pyqube/events/tests/test_ticket_handler.py
+++ b/pyqube/events/tests/test_ticket_handler.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 from pyqube.events.exceptions import InvalidTicketHandlerArgumentsError
 from pyqube.events.handlers import TicketHandler
+from pyqube.types import AnsweringTicket, PublicTicket
 
 
 # Concrete subclass for testing purposes
@@ -31,10 +32,35 @@ class TestTicketHandler:
         handler = ticket_handler.on_ticket_called(counter_id=124)
         assert handler is not None
 
+    def test_on_ticket_called_with_counter_id_builds_correct_topic(self, ticket_handler):
+        """Test that on_ticket_called builds the correct topic for queue_id."""
+        ticket_handler.add_mqtt_handler = Mock()
+        ticket_handler.on_ticket_called(counter_id=124)
+        ticket_handler.add_mqtt_handler.assert_called_once_with(
+            "locations/1/counters/124/tickets/called", AnsweringTicket
+        )
+
     def test_on_ticket_called_with_queue_id(self, ticket_handler):
         """Test that on_ticket_called registers the correct handler for queue_id."""
         handler = ticket_handler.on_ticket_called(queue_id=90)
         assert handler is not None
+
+    def test_on_ticket_called_with_queue_id_builds_correct_topic(self, ticket_handler):
+        """Test that on_ticket_called builds the correct topic for queue_id."""
+        ticket_handler.add_mqtt_handler = Mock()
+        ticket_handler.on_ticket_called(queue_id=90)
+        ticket_handler.add_mqtt_handler.assert_called_once_with("locations/1/queues/90/tickets/called", AnsweringTicket)
+
+    def test_on_ticket_called_with_no_arguments(self, ticket_handler):
+        """Test that on_ticket_called registers the correct handler when no arguments are provided."""
+        handler = ticket_handler.on_ticket_called()
+        assert handler is not None
+
+    def test_on_ticket_called_with_no_arguments_builds_correct_topic(self, ticket_handler):
+        """Test that on_ticket_called builds the correct topic when no arguments are provided."""
+        ticket_handler.add_mqtt_handler = Mock()
+        ticket_handler.on_ticket_called()
+        ticket_handler.add_mqtt_handler.assert_called_once_with("locations/1/queues/+/tickets/called", AnsweringTicket)
 
     def test_invalid_ticket_handler_arguments(self, ticket_handler):
         """Test the behavior when both queue_id and counter_id are provided."""
@@ -45,3 +71,9 @@ class TestTicketHandler:
         """Test that on_ticket_changed_state registers the correct handler."""
         handler = ticket_handler.on_ticket_changed_state()
         assert handler is not None
+
+    def test_on_ticket_changed_state_builds_correct_topic(self, ticket_handler):
+        """Test that on_ticket_changed_state builds the correct topic."""
+        ticket_handler.add_mqtt_handler = Mock()
+        ticket_handler.on_ticket_changed_state()
+        ticket_handler.add_mqtt_handler.assert_called_once_with("locations/1/tickets/+/changed-state", PublicTicket)


### PR DESCRIPTION
- Use MQTT wildcard `+` when no `queue_id` and `counter_id` are provided
- Add tests