### PR TITLE
[Refactor] Rename `make_graphql_request` to `graphql_request`

### DIFF
--- a/pyqube/rest/clients.py
+++ b/pyqube/rest/clients.py
@@ -81,7 +81,7 @@ class RestClient:
         response = requests.put(self.base_url + path, headers=self.headers, params=params, data=data, timeout=10)
         return response
 
-    def make_graphql_request(self, data: str = None) -> Response:
+    def graphql_request(self, data: str = None) -> Response:
         """
         Mas a POST request to GraphQL endpoint. This method can be useful for Managers.
         Args:

--- a/pyqube/rest/queue_management_manager.py
+++ b/pyqube/rest/queue_management_manager.py
@@ -261,7 +261,7 @@ class QueueManagementManager:
                 queues_list=queues_list_id, first=page_size, after=after
             )
 
-            response = self.client.make_graphql_request(query)
+            response = self.client.graphql_request(query)
             self._validate_response(response)
 
             response_data = response.json()

--- a/pyqube/rest/tests/test_list_queues_of_queues_list.py
+++ b/pyqube/rest/tests/test_list_queues_of_queues_list.py
@@ -14,7 +14,7 @@ from pyqube.rest.graphql_generators import QueuesListGraphQLGenerator
 from pyqube.types import Queue
 
 
-@patch.object(RestClient, "make_graphql_request")
+@patch.object(RestClient, "graphql_request")
 class TestListQueuesOfQueuesList(unittest.TestCase):
 
     def setUp(self):
@@ -143,10 +143,10 @@ class TestListQueuesOfQueuesList(unittest.TestCase):
             item["schedule"] = int(base64.b64decode(item["schedule"]["id"]).decode('utf-8').split(":")[1])
         return Queue(**item)
 
-    def test_list_queues_of_queues_list_with_one_page_with_success(self, mock_make_graphql_request):
+    def test_list_queues_of_queues_list_with_one_page_with_success(self, mock_graphql_request):
         # def test_list_queues_of_queues_list_with_success(self):
         """Test list queues paginated and checks if a list of Queues is returned"""
-        mock_make_graphql_request.return_value.json.return_value = self.page_1_list_of_queues_of_queues_list_response
+        mock_graphql_request.return_value.json.return_value = self.page_1_list_of_queues_of_queues_list_response
 
         list_of_queues_of_queues_list_generator = self.qube_rest_client.get_queue_management_manager(
         ).list_queues_of_queues_list(self.queues_list_id)
@@ -161,13 +161,13 @@ class TestListQueuesOfQueuesList(unittest.TestCase):
         expected_query = QueuesListGraphQLGenerator.generate_query_body(
             queues_list=self.queues_list_id, first=10, after="\"\""
         )
-        mock_make_graphql_request.assert_called_once_with(expected_query)
+        mock_graphql_request.assert_called_once_with(expected_query)
 
-    def test_list_queues_of_queues_list_with_multiple_pages_with_success(self, mock_make_graphql_request):
+    def test_list_queues_of_queues_list_with_multiple_pages_with_success(self, mock_graphql_request):
         """Test list queues paginated and checks if a list of Queues is returned"""
         self.page_1_list_of_queues_of_queues_list_response["data"]["queues_lists_queues"]["pageInfo"]["hasNextPage"
                                                                                                       ] = True
-        mock_make_graphql_request.return_value.json.side_effect = [
+        mock_graphql_request.return_value.json.side_effect = [
             self.page_1_list_of_queues_of_queues_list_response, self.page_2_list_of_queues_of_queues_list_response
         ]
 
@@ -183,25 +183,27 @@ class TestListQueuesOfQueuesList(unittest.TestCase):
             self.assertEqual(page_with_queues, expected_queues_list_pages[page - 1])
             page += 1
 
-        mock_make_graphql_request.assert_has_calls([
-            call(
-                QueuesListGraphQLGenerator.generate_query_body(
-                    queues_list=self.queues_list_id, first=page_size, after="\"\""
-                )
-            ),
-            call(
-                QueuesListGraphQLGenerator.generate_query_body(
-                    queues_list=self.queues_list_id, first=page_size, after="\"end_cursor_1\""
-                )
-            ),
-        ],
-                                                   any_order=True)
+        mock_graphql_request.assert_has_calls(
+            [
+                call(
+                    QueuesListGraphQLGenerator.generate_query_body(
+                        queues_list=self.queues_list_id, first=page_size, after="\"\""
+                    )
+                ),
+                call(
+                    QueuesListGraphQLGenerator.generate_query_body(
+                        queues_list=self.queues_list_id, first=page_size, after="\"end_cursor_1\""
+                    )
+                ),
+            ],
+            any_order=True,
+        )
 
-    def test_list_queues_of_queues_list_without_queues_with_success(self, mock_make_graphql_request):
+    def test_list_queues_of_queues_list_without_queues_with_success(self, mock_graphql_request):
         """Test list queues paginated and checks if a list of Queues is returned"""
 
         self.page_1_list_of_queues_of_queues_list_response["data"]["queues_lists_queues"]["edges"] = []
-        mock_make_graphql_request.return_value.json.return_value = self.page_1_list_of_queues_of_queues_list_response
+        mock_graphql_request.return_value.json.return_value = self.page_1_list_of_queues_of_queues_list_response
 
         list_of_queues_generator = self.qube_rest_client.get_queue_management_manager().list_queues_of_queues_list(
             self.queues_list_id
@@ -213,7 +215,7 @@ class TestListQueuesOfQueuesList(unittest.TestCase):
         expected_query = QueuesListGraphQLGenerator.generate_query_body(
             queues_list=self.queues_list_id, first=10, after="\"\""
         )
-        mock_make_graphql_request.assert_called_once_with(expected_query)
+        mock_graphql_request.assert_called_once_with(expected_query)
 
     def test_list_queues_of_queues_list_for_bad_request(self, mock_get_request):
         """Test list queues paginated to raises an Exception (BadRequest)"""


### PR DESCRIPTION
- Updated method name in `RestClient` for consistency
- Adjusted references in `QueueManagementManager` and tests to reflect the new method name